### PR TITLE
Signatures -> Signature

### DIFF
--- a/iroha/helper/stateless_validator.py
+++ b/iroha/helper/stateless_validator.py
@@ -44,7 +44,7 @@ def verify(transaction):
             logger.info("Stateless Command Failed")
             return False
 
-    for signature in transaction.signatures:
+    for signature in transaction.signature:
         if not crypto.verify(signature.pubkey,
                              signature.signature,
                              crypto.sign_hash(payload)):

--- a/iroha/primitive/signatories.py
+++ b/iroha/primitive/signatories.py
@@ -15,8 +15,8 @@ class Signatories:
         logger.debug("Signatories.sign")
         payload = tx.payload
         for signatory in self.signatories:
-            if not [ signature for signature in tx.signatures if signature.pubkey == signatory.public_key ]:
-                tx.signatures.extend([
+            if not [ signature for signature in tx.signature if signature.pubkey == signatory.public_key ]:
+                tx.signature.extend([
                     Signature(
                         pubkey = signatory.public_key,
                         signature = crypto.sign(signatory, crypto.sign_hash(payload))

--- a/iroha/transaction/transaction.py
+++ b/iroha/transaction/transaction.py
@@ -14,7 +14,7 @@ class Transaction:
             payload = TransactionSchema.Payload(
                 created_time = crypto.now()
             ),
-            signatures = []
+            signature = []
         )
         self.signatories = Signatories()
 
@@ -89,8 +89,8 @@ class Transaction:
         Delete all signature info. ( So, after call this func number of signatures of transaction is 0 )
         """
         logger.debug("Transaction.signatures_clean")
-        while self.tx.signatures.__len__():
-            self.tx.signatures.pop()
+        while self.tx.signature.__len__():
+            self.tx.signature.pop()
 
     def count_signatures(self):
         """
@@ -100,7 +100,7 @@ class Transaction:
 
         """
         logger.debug("Transaction.count_signatures")
-        return self.tx.signatures.__len__()
+        return self.tx.signature.__len__()
 
     def signatories_clean(self):
         """

--- a/schema/transaction.proto
+++ b/schema/transaction.proto
@@ -12,5 +12,5 @@ message Transaction {
     }
 
     Payload payload = 1;
-    repeated Signature signatures = 2;
+    repeated Signature signature = 2;
 }

--- a/tests/helper/test_crypt.py
+++ b/tests/helper/test_crypt.py
@@ -27,7 +27,7 @@ class CryptTest(unittest.TestCase):
 
         self.tx = Transaction(
             payload = self.payload,
-            signatures = [
+            signature = [
                 Signature(
                     pubkey = self.keypair.public_key,
                     signature = crypto.sign(self.keypair,crypto.sign_hash(self.payload))

--- a/tests/helper/test_stateless_validator.py
+++ b/tests/helper/test_stateless_validator.py
@@ -34,7 +34,7 @@ class TestCommand(unittest.TestCase):
 
         tx = Transaction(
             payload = payload,
-            signatures = [
+            signature = [
                 Signature(
                     pubkey = self.keypair.public_key,
                     signature = crypto.sign(self.keypair,crypto.sign_hash(payload))
@@ -61,7 +61,7 @@ class TestCommand(unittest.TestCase):
 
         tx = Transaction(
             payload = payload,
-            signatures = [
+            signature = [
                 Signature(
                     pubkey = self.keypair.public_key,
                     signature = crypto.sign(self.keypair,crypto.sign_hash(payload))
@@ -81,7 +81,7 @@ class TestCommand(unittest.TestCase):
 
         tx = Transaction(
             payload = payload,
-            signatures = [
+            signature = [
                 Signature(
                     pubkey = self.keypair.public_key,
                     signature = crypto.sign(self.keypair,crypto.sign_hash(payload))
@@ -117,7 +117,7 @@ class TestCommand(unittest.TestCase):
         )
         tx = Transaction(
             payload = payload,
-            signatures = [
+            signature = [
                 Signature(
                     pubkey = self.keypair.public_key,
                     signature = crypto.sign(self.keypair,crypto.sign_hash(payload2))

--- a/tests/primitive/test_signatories.py
+++ b/tests/primitive/test_signatories.py
@@ -28,14 +28,14 @@ class PrimitiveTest(unittest.TestCase):
             payload = Transaction.Payload(
                 creator_account_id = "test@test"
             ),
-            signatures = []
+            signature = []
         )
 
         signatories.sign(tx)
 
-        self.assertEqual(len(tx.signatures),3)
+        self.assertEqual(len(tx.signature),3)
         for i in range(0,3):
-            sig = tx.signatures[i]
+            sig = tx.signature[i]
             self.assertTrue(
                 crypto.verify(
                     sig.pubkey,

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -33,7 +33,7 @@ class CreatorTest(unittest.TestCase):
                     creator_account_id = "test@test",
                     created_time = tx.debug_proto_transaction().payload.created_time
                 ),
-                signatures = [
+                signature = [
                     Signature(
                         pubkey = keypairs[0].public_key,
                         signature = crypto.sign(


### PR DESCRIPTION
# Goal
In Hyperledger / iroha, Signatures of Transaction is handled as singular, not plural.
( refrence : https://github.com/hyperledger/iroha/pull/604 )
