### PR TITLE
Fix batch method for python 3.7, add support fot GetBlock, vbump 0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Please explore [examples](examples) directory for more usage examples.
 
 All the library methods have docstrings in its source [iroha.py](iroha/iroha.py).
 
-
+*The links above are broken outside the [hyperledger/iroha-python](https://github.com/hyperledger/iroha-python) GitHub repository.*

--- a/examples/batch-example.py
+++ b/examples/batch-example.py
@@ -145,7 +145,7 @@ def alice_creates_exchange_batch():
         # alice does not know bob's quorum.
         # bob knowing own quorum in case of accept should sign the tx using all the number of missing keys at once
     )
-    iroha.batch(alice_tx, bob_tx, atomic=True)
+    iroha.batch([alice_tx, bob_tx], atomic=True)
     # sign transactions only after batch meta creation
     ic.sign_transaction(alice_tx, *alice_private_keys)
     send_batch_and_print_status(alice_tx, bob_tx)

--- a/iroha/iroha.py
+++ b/iroha/iroha.py
@@ -266,7 +266,7 @@ class Iroha(object):
         return query_wrapper
 
     @staticmethod
-    def batch(atomic=True, *transactions):
+    def batch(transactions, atomic=True):
         """
         Tie transactions to be a single batch. All of them will have a common batch meta.
         :param transactions: list of transactions to be tied into a batch

--- a/iroha/qry_responses_pb2.py
+++ b/iroha/qry_responses_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='iroha.protocol',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x13qry_responses.proto\x12\x0eiroha.protocol\x1a\x0b\x62lock.proto\x1a\x11transaction.proto\x1a\x0fprimitive.proto\"?\n\x05\x41sset\x12\x10\n\x08\x61sset_id\x18\x01 \x01(\t\x12\x11\n\tdomain_id\x18\x02 \x01(\t\x12\x11\n\tprecision\x18\x03 \x01(\r\"1\n\x06\x44omain\x12\x11\n\tdomain_id\x18\x01 \x01(\t\x12\x14\n\x0c\x64\x65\x66\x61ult_role\x18\x02 \x01(\t\"S\n\x07\x41\x63\x63ount\x12\x12\n\naccount_id\x18\x01 \x01(\t\x12\x11\n\tdomain_id\x18\x02 \x01(\t\x12\x0e\n\x06quorum\x18\x03 \x01(\r\x12\x11\n\tjson_data\x18\x04 \x01(\t\"E\n\x0c\x41\x63\x63ountAsset\x12\x10\n\x08\x61sset_id\x18\x01 \x01(\t\x12\x12\n\naccount_id\x18\x02 \x01(\t\x12\x0f\n\x07\x62\x61lance\x18\x03 \x01(\t\"L\n\x14\x41\x63\x63ountAssetResponse\x12\x34\n\x0e\x61\x63\x63ount_assets\x18\x01 \x03(\x0b\x32\x1c.iroha.protocol.AccountAsset\"\'\n\x15\x41\x63\x63ountDetailResponse\x12\x0e\n\x06\x64\x65tail\x18\x01 \x01(\t\"R\n\x0f\x41\x63\x63ountResponse\x12(\n\x07\x61\x63\x63ount\x18\x01 \x01(\x0b\x32\x17.iroha.protocol.Account\x12\x15\n\raccount_roles\x18\x02 \x03(\t\"5\n\rAssetResponse\x12$\n\x05\x61sset\x18\x01 \x01(\x0b\x32\x15.iroha.protocol.Asset\"\x1e\n\rRolesResponse\x12\r\n\x05roles\x18\x01 \x03(\t\"N\n\x17RolePermissionsResponse\x12\x33\n\x0bpermissions\x18\x01 \x03(\x0e\x32\x1e.iroha.protocol.RolePermission\"\xa3\x02\n\rErrorResponse\x12\x34\n\x06reason\x18\x01 \x01(\x0e\x32$.iroha.protocol.ErrorResponse.Reason\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x12\n\nerror_code\x18\x03 \x01(\r\"\xb6\x01\n\x06Reason\x12\x15\n\x11STATELESS_INVALID\x10\x00\x12\x14\n\x10STATEFUL_INVALID\x10\x01\x12\x0e\n\nNO_ACCOUNT\x10\x02\x12\x15\n\x11NO_ACCOUNT_ASSETS\x10\x03\x12\x15\n\x11NO_ACCOUNT_DETAIL\x10\x04\x12\x12\n\x0eNO_SIGNATORIES\x10\x05\x12\x11\n\rNOT_SUPPORTED\x10\x06\x12\x0c\n\x08NO_ASSET\x10\x07\x12\x0c\n\x08NO_ROLES\x10\x08\"#\n\x13SignatoriesResponse\x12\x0c\n\x04keys\x18\x01 \x03(\t\"I\n\x14TransactionsResponse\x12\x31\n\x0ctransactions\x18\x01 \x03(\x0b\x32\x1b.iroha.protocol.Transaction\"\x95\x01\n\x18TransactionsPageResponse\x12\x31\n\x0ctransactions\x18\x01 \x03(\x0b\x32\x1b.iroha.protocol.Transaction\x12\x1d\n\x15\x61ll_transactions_size\x18\x02 \x01(\r\x12\x16\n\x0cnext_tx_hash\x18\x03 \x01(\tH\x00\x42\x0f\n\rnext_page_tag\"\xd4\x05\n\rQueryResponse\x12G\n\x17\x61\x63\x63ount_assets_response\x18\x01 \x01(\x0b\x32$.iroha.protocol.AccountAssetResponseH\x00\x12H\n\x17\x61\x63\x63ount_detail_response\x18\x02 \x01(\x0b\x32%.iroha.protocol.AccountDetailResponseH\x00\x12;\n\x10\x61\x63\x63ount_response\x18\x03 \x01(\x0b\x32\x1f.iroha.protocol.AccountResponseH\x00\x12\x37\n\x0e\x65rror_response\x18\x04 \x01(\x0b\x32\x1d.iroha.protocol.ErrorResponseH\x00\x12\x43\n\x14signatories_response\x18\x05 \x01(\x0b\x32#.iroha.protocol.SignatoriesResponseH\x00\x12\x45\n\x15transactions_response\x18\x06 \x01(\x0b\x32$.iroha.protocol.TransactionsResponseH\x00\x12\x37\n\x0e\x61sset_response\x18\x07 \x01(\x0b\x32\x1d.iroha.protocol.AssetResponseH\x00\x12\x37\n\x0eroles_response\x18\x08 \x01(\x0b\x32\x1d.iroha.protocol.RolesResponseH\x00\x12L\n\x19role_permissions_response\x18\t \x01(\x0b\x32\'.iroha.protocol.RolePermissionsResponseH\x00\x12N\n\x1atransactions_page_response\x18\x0b \x01(\x0b\x32(.iroha.protocol.TransactionsPageResponseH\x00\x12\x12\n\nquery_hash\x18\n \x01(\tB\n\n\x08response\"5\n\rBlockResponse\x12$\n\x05\x62lock\x18\x01 \x01(\x0b\x32\x15.iroha.protocol.Block\"%\n\x12\x42lockErrorResponse\x12\x0f\n\x07message\x18\x01 \x01(\t\"\x9d\x01\n\x12\x42lockQueryResponse\x12\x37\n\x0e\x62lock_response\x18\x01 \x01(\x0b\x32\x1d.iroha.protocol.BlockResponseH\x00\x12\x42\n\x14\x62lock_error_response\x18\x02 \x01(\x0b\x32\".iroha.protocol.BlockErrorResponseH\x00\x42\n\n\x08responseb\x06proto3')
+  serialized_pb=_b('\n\x13qry_responses.proto\x12\x0eiroha.protocol\x1a\x0b\x62lock.proto\x1a\x11transaction.proto\x1a\x0fprimitive.proto\"?\n\x05\x41sset\x12\x10\n\x08\x61sset_id\x18\x01 \x01(\t\x12\x11\n\tdomain_id\x18\x02 \x01(\t\x12\x11\n\tprecision\x18\x03 \x01(\r\"1\n\x06\x44omain\x12\x11\n\tdomain_id\x18\x01 \x01(\t\x12\x14\n\x0c\x64\x65\x66\x61ult_role\x18\x02 \x01(\t\"S\n\x07\x41\x63\x63ount\x12\x12\n\naccount_id\x18\x01 \x01(\t\x12\x11\n\tdomain_id\x18\x02 \x01(\t\x12\x0e\n\x06quorum\x18\x03 \x01(\r\x12\x11\n\tjson_data\x18\x04 \x01(\t\"E\n\x0c\x41\x63\x63ountAsset\x12\x10\n\x08\x61sset_id\x18\x01 \x01(\t\x12\x12\n\naccount_id\x18\x02 \x01(\t\x12\x0f\n\x07\x62\x61lance\x18\x03 \x01(\t\"L\n\x14\x41\x63\x63ountAssetResponse\x12\x34\n\x0e\x61\x63\x63ount_assets\x18\x01 \x03(\x0b\x32\x1c.iroha.protocol.AccountAsset\"\'\n\x15\x41\x63\x63ountDetailResponse\x12\x0e\n\x06\x64\x65tail\x18\x01 \x01(\t\"R\n\x0f\x41\x63\x63ountResponse\x12(\n\x07\x61\x63\x63ount\x18\x01 \x01(\x0b\x32\x17.iroha.protocol.Account\x12\x15\n\raccount_roles\x18\x02 \x03(\t\"5\n\rAssetResponse\x12$\n\x05\x61sset\x18\x01 \x01(\x0b\x32\x15.iroha.protocol.Asset\"\x1e\n\rRolesResponse\x12\r\n\x05roles\x18\x01 \x03(\t\"N\n\x17RolePermissionsResponse\x12\x33\n\x0bpermissions\x18\x01 \x03(\x0e\x32\x1e.iroha.protocol.RolePermission\"\xa3\x02\n\rErrorResponse\x12\x34\n\x06reason\x18\x01 \x01(\x0e\x32$.iroha.protocol.ErrorResponse.Reason\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x12\n\nerror_code\x18\x03 \x01(\r\"\xb6\x01\n\x06Reason\x12\x15\n\x11STATELESS_INVALID\x10\x00\x12\x14\n\x10STATEFUL_INVALID\x10\x01\x12\x0e\n\nNO_ACCOUNT\x10\x02\x12\x15\n\x11NO_ACCOUNT_ASSETS\x10\x03\x12\x15\n\x11NO_ACCOUNT_DETAIL\x10\x04\x12\x12\n\x0eNO_SIGNATORIES\x10\x05\x12\x11\n\rNOT_SUPPORTED\x10\x06\x12\x0c\n\x08NO_ASSET\x10\x07\x12\x0c\n\x08NO_ROLES\x10\x08\"#\n\x13SignatoriesResponse\x12\x0c\n\x04keys\x18\x01 \x03(\t\"I\n\x14TransactionsResponse\x12\x31\n\x0ctransactions\x18\x01 \x03(\x0b\x32\x1b.iroha.protocol.Transaction\"\x95\x01\n\x18TransactionsPageResponse\x12\x31\n\x0ctransactions\x18\x01 \x03(\x0b\x32\x1b.iroha.protocol.Transaction\x12\x1d\n\x15\x61ll_transactions_size\x18\x02 \x01(\r\x12\x16\n\x0cnext_tx_hash\x18\x03 \x01(\tH\x00\x42\x0f\n\rnext_page_tag\"\x8d\x06\n\rQueryResponse\x12G\n\x17\x61\x63\x63ount_assets_response\x18\x01 \x01(\x0b\x32$.iroha.protocol.AccountAssetResponseH\x00\x12H\n\x17\x61\x63\x63ount_detail_response\x18\x02 \x01(\x0b\x32%.iroha.protocol.AccountDetailResponseH\x00\x12;\n\x10\x61\x63\x63ount_response\x18\x03 \x01(\x0b\x32\x1f.iroha.protocol.AccountResponseH\x00\x12\x37\n\x0e\x65rror_response\x18\x04 \x01(\x0b\x32\x1d.iroha.protocol.ErrorResponseH\x00\x12\x43\n\x14signatories_response\x18\x05 \x01(\x0b\x32#.iroha.protocol.SignatoriesResponseH\x00\x12\x45\n\x15transactions_response\x18\x06 \x01(\x0b\x32$.iroha.protocol.TransactionsResponseH\x00\x12\x37\n\x0e\x61sset_response\x18\x07 \x01(\x0b\x32\x1d.iroha.protocol.AssetResponseH\x00\x12\x37\n\x0eroles_response\x18\x08 \x01(\x0b\x32\x1d.iroha.protocol.RolesResponseH\x00\x12L\n\x19role_permissions_response\x18\t \x01(\x0b\x32\'.iroha.protocol.RolePermissionsResponseH\x00\x12N\n\x1atransactions_page_response\x18\x0b \x01(\x0b\x32(.iroha.protocol.TransactionsPageResponseH\x00\x12\x37\n\x0e\x62lock_response\x18\x0c \x01(\x0b\x32\x1d.iroha.protocol.BlockResponseH\x00\x12\x12\n\nquery_hash\x18\n \x01(\tB\n\n\x08response\"5\n\rBlockResponse\x12$\n\x05\x62lock\x18\x01 \x01(\x0b\x32\x15.iroha.protocol.Block\"%\n\x12\x42lockErrorResponse\x12\x0f\n\x07message\x18\x01 \x01(\t\"\x9d\x01\n\x12\x42lockQueryResponse\x12\x37\n\x0e\x62lock_response\x18\x01 \x01(\x0b\x32\x1d.iroha.protocol.BlockResponseH\x00\x12\x42\n\x14\x62lock_error_response\x18\x02 \x01(\x0b\x32\".iroha.protocol.BlockErrorResponseH\x00\x42\n\n\x08responseb\x06proto3')
   ,
   dependencies=[block__pb2.DESCRIPTOR,transaction__pb2.DESCRIPTOR,primitive__pb2.DESCRIPTOR,])
 
@@ -686,7 +686,14 @@ _QUERYRESPONSE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='query_hash', full_name='iroha.protocol.QueryResponse.query_hash', index=10,
+      name='block_response', full_name='iroha.protocol.QueryResponse.block_response', index=10,
+      number=12, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='query_hash', full_name='iroha.protocol.QueryResponse.query_hash', index=11,
       number=10, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -708,7 +715,7 @@ _QUERYRESPONSE = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=1289,
-  serialized_end=2013,
+  serialized_end=2070,
 )
 
 
@@ -738,8 +745,8 @@ _BLOCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2015,
-  serialized_end=2068,
+  serialized_start=2072,
+  serialized_end=2125,
 )
 
 
@@ -769,8 +776,8 @@ _BLOCKERRORRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2070,
-  serialized_end=2107,
+  serialized_start=2127,
+  serialized_end=2164,
 )
 
 
@@ -810,8 +817,8 @@ _BLOCKQUERYRESPONSE = _descriptor.Descriptor(
       name='response', full_name='iroha.protocol.BlockQueryResponse.response',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2110,
-  serialized_end=2267,
+  serialized_start=2167,
+  serialized_end=2324,
 )
 
 _ACCOUNTASSETRESPONSE.fields_by_name['account_assets'].message_type = _ACCOUNTASSET
@@ -835,6 +842,7 @@ _QUERYRESPONSE.fields_by_name['asset_response'].message_type = _ASSETRESPONSE
 _QUERYRESPONSE.fields_by_name['roles_response'].message_type = _ROLESRESPONSE
 _QUERYRESPONSE.fields_by_name['role_permissions_response'].message_type = _ROLEPERMISSIONSRESPONSE
 _QUERYRESPONSE.fields_by_name['transactions_page_response'].message_type = _TRANSACTIONSPAGERESPONSE
+_QUERYRESPONSE.fields_by_name['block_response'].message_type = _BLOCKRESPONSE
 _QUERYRESPONSE.oneofs_by_name['response'].fields.append(
   _QUERYRESPONSE.fields_by_name['account_assets_response'])
 _QUERYRESPONSE.fields_by_name['account_assets_response'].containing_oneof = _QUERYRESPONSE.oneofs_by_name['response']
@@ -865,6 +873,9 @@ _QUERYRESPONSE.fields_by_name['role_permissions_response'].containing_oneof = _Q
 _QUERYRESPONSE.oneofs_by_name['response'].fields.append(
   _QUERYRESPONSE.fields_by_name['transactions_page_response'])
 _QUERYRESPONSE.fields_by_name['transactions_page_response'].containing_oneof = _QUERYRESPONSE.oneofs_by_name['response']
+_QUERYRESPONSE.oneofs_by_name['response'].fields.append(
+  _QUERYRESPONSE.fields_by_name['block_response'])
+_QUERYRESPONSE.fields_by_name['block_response'].containing_oneof = _QUERYRESPONSE.oneofs_by_name['response']
 _BLOCKRESPONSE.fields_by_name['block'].message_type = block__pb2._BLOCK
 _BLOCKQUERYRESPONSE.fields_by_name['block_response'].message_type = _BLOCKRESPONSE
 _BLOCKQUERYRESPONSE.fields_by_name['block_error_response'].message_type = _BLOCKERRORRESPONSE

--- a/iroha/queries_pb2.py
+++ b/iroha/queries_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='iroha.protocol',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\rqueries.proto\x12\x0eiroha.protocol\x1a\x0fprimitive.proto\"S\n\x10TxPaginationMeta\x12\x11\n\tpage_size\x18\x01 \x01(\r\x12\x17\n\rfirst_tx_hash\x18\x02 \x01(\tH\x00\x42\x13\n\x11opt_first_tx_hash\" \n\nGetAccount\x12\x12\n\naccount_id\x18\x01 \x01(\t\"$\n\x0eGetSignatories\x12\x12\n\naccount_id\x18\x01 \x01(\t\"g\n\x16GetAccountTransactions\x12\x12\n\naccount_id\x18\x01 \x01(\t\x12\x39\n\x0fpagination_meta\x18\x02 \x01(\x0b\x32 .iroha.protocol.TxPaginationMeta\"~\n\x1bGetAccountAssetTransactions\x12\x12\n\naccount_id\x18\x01 \x01(\t\x12\x10\n\x08\x61sset_id\x18\x02 \x01(\t\x12\x39\n\x0fpagination_meta\x18\x03 \x01(\x0b\x32 .iroha.protocol.TxPaginationMeta\"$\n\x0fGetTransactions\x12\x11\n\ttx_hashes\x18\x01 \x03(\t\"&\n\x10GetAccountAssets\x12\x12\n\naccount_id\x18\x01 \x01(\t\"t\n\x10GetAccountDetail\x12\x14\n\naccount_id\x18\x01 \x01(\tH\x00\x12\r\n\x03key\x18\x02 \x01(\tH\x01\x12\x10\n\x06writer\x18\x03 \x01(\tH\x02\x42\x10\n\x0eopt_account_idB\t\n\x07opt_keyB\x0c\n\nopt_writer\" \n\x0cGetAssetInfo\x12\x10\n\x08\x61sset_id\x18\x01 \x01(\t\"\n\n\x08GetRoles\"%\n\x12GetRolePermissions\x12\x0f\n\x07role_id\x18\x01 \x01(\t\"\x18\n\x16GetPendingTransactions\"[\n\x10QueryPayloadMeta\x12\x14\n\x0c\x63reated_time\x18\x01 \x01(\x04\x12\x1a\n\x12\x63reator_account_id\x18\x02 \x01(\t\x12\x15\n\rquery_counter\x18\x03 \x01(\x04\"\xef\x06\n\x05Query\x12.\n\x07payload\x18\x01 \x01(\x0b\x32\x1d.iroha.protocol.Query.Payload\x12,\n\tsignature\x18\x02 \x01(\x0b\x32\x19.iroha.protocol.Signature\x1a\x87\x06\n\x07Payload\x12.\n\x04meta\x18\x01 \x01(\x0b\x32 .iroha.protocol.QueryPayloadMeta\x12\x31\n\x0bget_account\x18\x03 \x01(\x0b\x32\x1a.iroha.protocol.GetAccountH\x00\x12\x39\n\x0fget_signatories\x18\x04 \x01(\x0b\x32\x1e.iroha.protocol.GetSignatoriesH\x00\x12J\n\x18get_account_transactions\x18\x05 \x01(\x0b\x32&.iroha.protocol.GetAccountTransactionsH\x00\x12U\n\x1eget_account_asset_transactions\x18\x06 \x01(\x0b\x32+.iroha.protocol.GetAccountAssetTransactionsH\x00\x12;\n\x10get_transactions\x18\x07 \x01(\x0b\x32\x1f.iroha.protocol.GetTransactionsH\x00\x12>\n\x12get_account_assets\x18\x08 \x01(\x0b\x32 .iroha.protocol.GetAccountAssetsH\x00\x12>\n\x12get_account_detail\x18\t \x01(\x0b\x32 .iroha.protocol.GetAccountDetailH\x00\x12-\n\tget_roles\x18\n \x01(\x0b\x32\x18.iroha.protocol.GetRolesH\x00\x12\x42\n\x14get_role_permissions\x18\x0b \x01(\x0b\x32\".iroha.protocol.GetRolePermissionsH\x00\x12\x36\n\x0eget_asset_info\x18\x0c \x01(\x0b\x32\x1c.iroha.protocol.GetAssetInfoH\x00\x12J\n\x18get_pending_transactions\x18\r \x01(\x0b\x32&.iroha.protocol.GetPendingTransactionsH\x00\x42\x07\n\x05query\"k\n\x0b\x42locksQuery\x12.\n\x04meta\x18\x01 \x01(\x0b\x32 .iroha.protocol.QueryPayloadMeta\x12,\n\tsignature\x18\x02 \x01(\x0b\x32\x19.iroha.protocol.Signatureb\x06proto3')
+  serialized_pb=_b('\n\rqueries.proto\x12\x0eiroha.protocol\x1a\x0fprimitive.proto\"S\n\x10TxPaginationMeta\x12\x11\n\tpage_size\x18\x01 \x01(\r\x12\x17\n\rfirst_tx_hash\x18\x02 \x01(\tH\x00\x42\x13\n\x11opt_first_tx_hash\" \n\nGetAccount\x12\x12\n\naccount_id\x18\x01 \x01(\t\"\x1a\n\x08GetBlock\x12\x0e\n\x06height\x18\x01 \x01(\x04\"$\n\x0eGetSignatories\x12\x12\n\naccount_id\x18\x01 \x01(\t\"g\n\x16GetAccountTransactions\x12\x12\n\naccount_id\x18\x01 \x01(\t\x12\x39\n\x0fpagination_meta\x18\x02 \x01(\x0b\x32 .iroha.protocol.TxPaginationMeta\"~\n\x1bGetAccountAssetTransactions\x12\x12\n\naccount_id\x18\x01 \x01(\t\x12\x10\n\x08\x61sset_id\x18\x02 \x01(\t\x12\x39\n\x0fpagination_meta\x18\x03 \x01(\x0b\x32 .iroha.protocol.TxPaginationMeta\"$\n\x0fGetTransactions\x12\x11\n\ttx_hashes\x18\x01 \x03(\t\"&\n\x10GetAccountAssets\x12\x12\n\naccount_id\x18\x01 \x01(\t\"t\n\x10GetAccountDetail\x12\x14\n\naccount_id\x18\x01 \x01(\tH\x00\x12\r\n\x03key\x18\x02 \x01(\tH\x01\x12\x10\n\x06writer\x18\x03 \x01(\tH\x02\x42\x10\n\x0eopt_account_idB\t\n\x07opt_keyB\x0c\n\nopt_writer\" \n\x0cGetAssetInfo\x12\x10\n\x08\x61sset_id\x18\x01 \x01(\t\"\n\n\x08GetRoles\"%\n\x12GetRolePermissions\x12\x0f\n\x07role_id\x18\x01 \x01(\t\"\x18\n\x16GetPendingTransactions\"[\n\x10QueryPayloadMeta\x12\x14\n\x0c\x63reated_time\x18\x01 \x01(\x04\x12\x1a\n\x12\x63reator_account_id\x18\x02 \x01(\t\x12\x15\n\rquery_counter\x18\x03 \x01(\x04\"\x9e\x07\n\x05Query\x12.\n\x07payload\x18\x01 \x01(\x0b\x32\x1d.iroha.protocol.Query.Payload\x12,\n\tsignature\x18\x02 \x01(\x0b\x32\x19.iroha.protocol.Signature\x1a\xb6\x06\n\x07Payload\x12.\n\x04meta\x18\x01 \x01(\x0b\x32 .iroha.protocol.QueryPayloadMeta\x12\x31\n\x0bget_account\x18\x03 \x01(\x0b\x32\x1a.iroha.protocol.GetAccountH\x00\x12\x39\n\x0fget_signatories\x18\x04 \x01(\x0b\x32\x1e.iroha.protocol.GetSignatoriesH\x00\x12J\n\x18get_account_transactions\x18\x05 \x01(\x0b\x32&.iroha.protocol.GetAccountTransactionsH\x00\x12U\n\x1eget_account_asset_transactions\x18\x06 \x01(\x0b\x32+.iroha.protocol.GetAccountAssetTransactionsH\x00\x12;\n\x10get_transactions\x18\x07 \x01(\x0b\x32\x1f.iroha.protocol.GetTransactionsH\x00\x12>\n\x12get_account_assets\x18\x08 \x01(\x0b\x32 .iroha.protocol.GetAccountAssetsH\x00\x12>\n\x12get_account_detail\x18\t \x01(\x0b\x32 .iroha.protocol.GetAccountDetailH\x00\x12-\n\tget_roles\x18\n \x01(\x0b\x32\x18.iroha.protocol.GetRolesH\x00\x12\x42\n\x14get_role_permissions\x18\x0b \x01(\x0b\x32\".iroha.protocol.GetRolePermissionsH\x00\x12\x36\n\x0eget_asset_info\x18\x0c \x01(\x0b\x32\x1c.iroha.protocol.GetAssetInfoH\x00\x12J\n\x18get_pending_transactions\x18\r \x01(\x0b\x32&.iroha.protocol.GetPendingTransactionsH\x00\x12-\n\tget_block\x18\x0e \x01(\x0b\x32\x18.iroha.protocol.GetBlockH\x00\x42\x07\n\x05query\"k\n\x0b\x42locksQuery\x12.\n\x04meta\x18\x01 \x01(\x0b\x32 .iroha.protocol.QueryPayloadMeta\x12,\n\tsignature\x18\x02 \x01(\x0b\x32\x19.iroha.protocol.Signatureb\x06proto3')
   ,
   dependencies=[primitive__pb2.DESCRIPTOR,])
 
@@ -99,6 +99,37 @@ _GETACCOUNT = _descriptor.Descriptor(
 )
 
 
+_GETBLOCK = _descriptor.Descriptor(
+  name='GetBlock',
+  full_name='iroha.protocol.GetBlock',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='height', full_name='iroha.protocol.GetBlock.height', index=0,
+      number=1, type=4, cpp_type=4, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=169,
+  serialized_end=195,
+)
+
+
 _GETSIGNATORIES = _descriptor.Descriptor(
   name='GetSignatories',
   full_name='iroha.protocol.GetSignatories',
@@ -125,8 +156,8 @@ _GETSIGNATORIES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=169,
-  serialized_end=205,
+  serialized_start=197,
+  serialized_end=233,
 )
 
 
@@ -163,8 +194,8 @@ _GETACCOUNTTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=207,
-  serialized_end=310,
+  serialized_start=235,
+  serialized_end=338,
 )
 
 
@@ -208,8 +239,8 @@ _GETACCOUNTASSETTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=312,
-  serialized_end=438,
+  serialized_start=340,
+  serialized_end=466,
 )
 
 
@@ -239,8 +270,8 @@ _GETTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=440,
-  serialized_end=476,
+  serialized_start=468,
+  serialized_end=504,
 )
 
 
@@ -270,8 +301,8 @@ _GETACCOUNTASSETS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=478,
-  serialized_end=516,
+  serialized_start=506,
+  serialized_end=544,
 )
 
 
@@ -324,8 +355,8 @@ _GETACCOUNTDETAIL = _descriptor.Descriptor(
       name='opt_writer', full_name='iroha.protocol.GetAccountDetail.opt_writer',
       index=2, containing_type=None, fields=[]),
   ],
-  serialized_start=518,
-  serialized_end=634,
+  serialized_start=546,
+  serialized_end=662,
 )
 
 
@@ -355,8 +386,8 @@ _GETASSETINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=636,
-  serialized_end=668,
+  serialized_start=664,
+  serialized_end=696,
 )
 
 
@@ -379,8 +410,8 @@ _GETROLES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=670,
-  serialized_end=680,
+  serialized_start=698,
+  serialized_end=708,
 )
 
 
@@ -410,8 +441,8 @@ _GETROLEPERMISSIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=682,
-  serialized_end=719,
+  serialized_start=710,
+  serialized_end=747,
 )
 
 
@@ -434,8 +465,8 @@ _GETPENDINGTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=721,
-  serialized_end=745,
+  serialized_start=749,
+  serialized_end=773,
 )
 
 
@@ -479,8 +510,8 @@ _QUERYPAYLOADMETA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=747,
-  serialized_end=838,
+  serialized_start=775,
+  serialized_end=866,
 )
 
 
@@ -575,6 +606,13 @@ _QUERY_PAYLOAD = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='get_block', full_name='iroha.protocol.Query.Payload.get_block', index=12,
+      number=14, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -590,8 +628,8 @@ _QUERY_PAYLOAD = _descriptor.Descriptor(
       name='query', full_name='iroha.protocol.Query.Payload.query',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=945,
-  serialized_end=1720,
+  serialized_start=973,
+  serialized_end=1795,
 )
 
 _QUERY = _descriptor.Descriptor(
@@ -627,8 +665,8 @@ _QUERY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=841,
-  serialized_end=1720,
+  serialized_start=869,
+  serialized_end=1795,
 )
 
 
@@ -665,8 +703,8 @@ _BLOCKSQUERY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1722,
-  serialized_end=1829,
+  serialized_start=1797,
+  serialized_end=1904,
 )
 
 _TXPAGINATIONMETA.oneofs_by_name['opt_first_tx_hash'].fields.append(
@@ -695,6 +733,7 @@ _QUERY_PAYLOAD.fields_by_name['get_roles'].message_type = _GETROLES
 _QUERY_PAYLOAD.fields_by_name['get_role_permissions'].message_type = _GETROLEPERMISSIONS
 _QUERY_PAYLOAD.fields_by_name['get_asset_info'].message_type = _GETASSETINFO
 _QUERY_PAYLOAD.fields_by_name['get_pending_transactions'].message_type = _GETPENDINGTRANSACTIONS
+_QUERY_PAYLOAD.fields_by_name['get_block'].message_type = _GETBLOCK
 _QUERY_PAYLOAD.containing_type = _QUERY
 _QUERY_PAYLOAD.oneofs_by_name['query'].fields.append(
   _QUERY_PAYLOAD.fields_by_name['get_account'])
@@ -729,12 +768,16 @@ _QUERY_PAYLOAD.fields_by_name['get_asset_info'].containing_oneof = _QUERY_PAYLOA
 _QUERY_PAYLOAD.oneofs_by_name['query'].fields.append(
   _QUERY_PAYLOAD.fields_by_name['get_pending_transactions'])
 _QUERY_PAYLOAD.fields_by_name['get_pending_transactions'].containing_oneof = _QUERY_PAYLOAD.oneofs_by_name['query']
+_QUERY_PAYLOAD.oneofs_by_name['query'].fields.append(
+  _QUERY_PAYLOAD.fields_by_name['get_block'])
+_QUERY_PAYLOAD.fields_by_name['get_block'].containing_oneof = _QUERY_PAYLOAD.oneofs_by_name['query']
 _QUERY.fields_by_name['payload'].message_type = _QUERY_PAYLOAD
 _QUERY.fields_by_name['signature'].message_type = primitive__pb2._SIGNATURE
 _BLOCKSQUERY.fields_by_name['meta'].message_type = _QUERYPAYLOADMETA
 _BLOCKSQUERY.fields_by_name['signature'].message_type = primitive__pb2._SIGNATURE
 DESCRIPTOR.message_types_by_name['TxPaginationMeta'] = _TXPAGINATIONMETA
 DESCRIPTOR.message_types_by_name['GetAccount'] = _GETACCOUNT
+DESCRIPTOR.message_types_by_name['GetBlock'] = _GETBLOCK
 DESCRIPTOR.message_types_by_name['GetSignatories'] = _GETSIGNATORIES
 DESCRIPTOR.message_types_by_name['GetAccountTransactions'] = _GETACCOUNTTRANSACTIONS
 DESCRIPTOR.message_types_by_name['GetAccountAssetTransactions'] = _GETACCOUNTASSETTRANSACTIONS
@@ -763,6 +806,13 @@ GetAccount = _reflection.GeneratedProtocolMessageType('GetAccount', (_message.Me
   # @@protoc_insertion_point(class_scope:iroha.protocol.GetAccount)
   ))
 _sym_db.RegisterMessage(GetAccount)
+
+GetBlock = _reflection.GeneratedProtocolMessageType('GetBlock', (_message.Message,), dict(
+  DESCRIPTOR = _GETBLOCK,
+  __module__ = 'queries_pb2'
+  # @@protoc_insertion_point(class_scope:iroha.protocol.GetBlock)
+  ))
+_sym_db.RegisterMessage(GetBlock)
 
 GetSignatories = _reflection.GeneratedProtocolMessageType('GetSignatories', (_message.Message,), dict(
   DESCRIPTOR = _GETSIGNATORIES,

--- a/schema/qry_responses.proto
+++ b/schema/qry_responses.proto
@@ -105,6 +105,7 @@ message QueryResponse {
     RolesResponse roles_response = 8;
     RolePermissionsResponse role_permissions_response = 9;
     TransactionsPageResponse transactions_page_response = 11;
+    BlockResponse block_response = 12;
   }
   string query_hash = 10;
 }

--- a/schema/queries.proto
+++ b/schema/queries.proto
@@ -19,6 +19,10 @@ message GetAccount {
   string account_id = 1;
 }
 
+message GetBlock {
+  uint64 height = 1;
+}
+
 message GetSignatories {
   string account_id = 1;
 }
@@ -93,6 +97,7 @@ message Query {
        GetRolePermissions get_role_permissions = 11;
        GetAssetInfo get_asset_info = 12;
        GetPendingTransactions get_pending_transactions = 13;
+       GetBlock get_block = 14;
      }
   }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,3 +8,16 @@ Here are stored the scripts that help build a wheel for pypi repository:
 **Most likely you do NOT need those scripts.**
 
 Anyway, they can successfully run inside `hyperledger/iroha:develop-build` Docker container.
+
+You may need to build the wheel on your own only in exceptional cases.
+Please use `pip install iroha` or `pip install --upgrade iroha` by default.
+
+The wheel itself can be built and installed with:
+
+```bash
+cd iroha-python
+scripts/download-schema.py
+scripts/compile-proto.py
+python3 setup.py bdist_wheel
+pip install dist/iroha*.whl
+```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as readme_file:
 
 setuptools.setup(
     name='iroha',
-    version='0.0.2',
+    version='0.0.3',
     description='Python library for Hyperledger Iroha',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Make `Iroha().batch()` method work again in Python 3.7.
Bump package version to `0.0.3`
Add support of `GetBlock` query.
Fix `batch-example.py`

### Usage Examples or Tests

```bash
examples/batch-example.py
```