### PR TITLE
Remove exception handling and make send_txs iface consistent with batch

### DIFF
--- a/examples/batch-example.py
+++ b/examples/batch-example.py
@@ -63,9 +63,9 @@ def send_transaction_and_print_status(transaction):
 
 
 @trace
-def send_batch_and_print_status(*transactions):
+def send_batch_and_print_status(transactions):
     global net
-    net.send_txs(*transactions)
+    net.send_txs(transactions)
     for tx in transactions:
         hex_hash = binascii.hexlify(ic.hash(tx))
         print('\t' + '-' * 20)
@@ -148,7 +148,7 @@ def alice_creates_exchange_batch():
     iroha.batch([alice_tx, bob_tx], atomic=True)
     # sign transactions only after batch meta creation
     ic.sign_transaction(alice_tx, *alice_private_keys)
-    send_batch_and_print_status(alice_tx, bob_tx)
+    send_batch_and_print_status([alice_tx, bob_tx])
 
 
 @trace
@@ -166,7 +166,7 @@ def bob_accepts_exchange_request():
         else:
             ic.sign_transaction(tx, *bob_private_keys)
     send_batch_and_print_status(
-        *pending_transactions.transactions_response.transactions)
+        pending_transactions.transactions_response.transactions)
 
 
 @trace
@@ -206,7 +206,7 @@ def bob_declines_exchange_request():
             ic.sign_transaction(tx, *alice_private_keys)
             # zeroes as private keys are also acceptable
     send_batch_and_print_status(
-        *pending_transactions.transactions_response.transactions)
+        pending_transactions.transactions_response.transactions)
 
 
 create_users()

--- a/iroha/endpoint_pb2.py
+++ b/iroha/endpoint_pb2.py
@@ -8,7 +8,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -24,6 +23,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='endpoint.proto',
   package='iroha.protocol',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\x0e\x65ndpoint.proto\x12\x0eiroha.protocol\x1a\x11transaction.proto\x1a\rqueries.proto\x1a\x13qry_responses.proto\x1a\x1bgoogle/protobuf/empty.proto\"\x94\x01\n\rToriiResponse\x12+\n\ttx_status\x18\x01 \x01(\x0e\x32\x18.iroha.protocol.TxStatus\x12\x0f\n\x07tx_hash\x18\x02 \x01(\t\x12\x17\n\x0f\x65rr_or_cmd_name\x18\x03 \x01(\t\x12\x18\n\x10\x66\x61iled_cmd_index\x18\x04 \x01(\x04\x12\x12\n\nerror_code\x18\x05 \x01(\r\"\"\n\x0fTxStatusRequest\x12\x0f\n\x07tx_hash\x18\x01 \x01(\t\";\n\x06TxList\x12\x31\n\x0ctransactions\x18\x01 \x03(\x0b\x32\x1b.iroha.protocol.Transaction*\x80\x02\n\x08TxStatus\x12\x1f\n\x1bSTATELESS_VALIDATION_FAILED\x10\x00\x12 \n\x1cSTATELESS_VALIDATION_SUCCESS\x10\x01\x12\x1e\n\x1aSTATEFUL_VALIDATION_FAILED\x10\x02\x12\x1f\n\x1bSTATEFUL_VALIDATION_SUCCESS\x10\x03\x12\x0c\n\x08REJECTED\x10\x04\x12\r\n\tCOMMITTED\x10\x05\x12\x0f\n\x0bMST_EXPIRED\x10\x06\x12\x10\n\x0cNOT_RECEIVED\x10\x07\x12\x0f\n\x0bMST_PENDING\x10\x08\x12\x1f\n\x1b\x45NOUGH_SIGNATURES_COLLECTED\x10\t2\xaa\x02\n\x11\x43ommandService_v1\x12<\n\x05Torii\x12\x1b.iroha.protocol.Transaction\x1a\x16.google.protobuf.Empty\x12;\n\tListTorii\x12\x16.iroha.protocol.TxList\x1a\x16.google.protobuf.Empty\x12H\n\x06Status\x12\x1f.iroha.protocol.TxStatusRequest\x1a\x1d.iroha.protocol.ToriiResponse\x12P\n\x0cStatusStream\x12\x1f.iroha.protocol.TxStatusRequest\x1a\x1d.iroha.protocol.ToriiResponse0\x01\x32\xa2\x01\n\x0fQueryService_v1\x12<\n\x04\x46ind\x12\x15.iroha.protocol.Query\x1a\x1d.iroha.protocol.QueryResponse\x12Q\n\x0c\x46\x65tchCommits\x12\x1b.iroha.protocol.BlocksQuery\x1a\".iroha.protocol.BlockQueryResponse0\x01\x62\x06proto3')
   ,
   dependencies=[transaction__pb2.DESCRIPTOR,queries__pb2.DESCRIPTOR,qry__responses__pb2.DESCRIPTOR,google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,])
@@ -36,47 +36,47 @@ _TXSTATUS = _descriptor.EnumDescriptor(
   values=[
     _descriptor.EnumValueDescriptor(
       name='STATELESS_VALIDATION_FAILED', index=0, number=0,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='STATELESS_VALIDATION_SUCCESS', index=1, number=1,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='STATEFUL_VALIDATION_FAILED', index=2, number=2,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='STATEFUL_VALIDATION_SUCCESS', index=3, number=3,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='REJECTED', index=4, number=4,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='COMMITTED', index=5, number=5,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='MST_EXPIRED', index=6, number=6,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='NOT_RECEIVED', index=7, number=7,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='MST_PENDING', index=8, number=8,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='ENOUGH_SIGNATURES_COLLECTED', index=9, number=9,
-      options=None,
+      serialized_options=None,
       type=None),
   ],
   containing_type=None,
-  options=None,
+  serialized_options=None,
   serialized_start=367,
   serialized_end=623,
 )
@@ -109,42 +109,42 @@ _TORIIRESPONSE = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='tx_hash', full_name='iroha.protocol.ToriiResponse.tx_hash', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='err_or_cmd_name', full_name='iroha.protocol.ToriiResponse.err_or_cmd_name', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='failed_cmd_index', full_name='iroha.protocol.ToriiResponse.failed_cmd_index', index=3,
       number=4, type=4, cpp_type=4, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='error_code', full_name='iroha.protocol.ToriiResponse.error_code', index=4,
       number=5, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -168,14 +168,14 @@ _TXSTATUSREQUEST = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -199,14 +199,14 @@ _TXLIST = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -252,7 +252,7 @@ _COMMANDSERVICE_V1 = _descriptor.ServiceDescriptor(
   full_name='iroha.protocol.CommandService_v1',
   file=DESCRIPTOR,
   index=0,
-  options=None,
+  serialized_options=None,
   serialized_start=626,
   serialized_end=924,
   methods=[
@@ -263,7 +263,7 @@ _COMMANDSERVICE_V1 = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=transaction__pb2._TRANSACTION,
     output_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
-    options=None,
+    serialized_options=None,
   ),
   _descriptor.MethodDescriptor(
     name='ListTorii',
@@ -272,7 +272,7 @@ _COMMANDSERVICE_V1 = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_TXLIST,
     output_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
-    options=None,
+    serialized_options=None,
   ),
   _descriptor.MethodDescriptor(
     name='Status',
@@ -281,7 +281,7 @@ _COMMANDSERVICE_V1 = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_TXSTATUSREQUEST,
     output_type=_TORIIRESPONSE,
-    options=None,
+    serialized_options=None,
   ),
   _descriptor.MethodDescriptor(
     name='StatusStream',
@@ -290,7 +290,7 @@ _COMMANDSERVICE_V1 = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_TXSTATUSREQUEST,
     output_type=_TORIIRESPONSE,
-    options=None,
+    serialized_options=None,
   ),
 ])
 _sym_db.RegisterServiceDescriptor(_COMMANDSERVICE_V1)
@@ -303,7 +303,7 @@ _QUERYSERVICE_V1 = _descriptor.ServiceDescriptor(
   full_name='iroha.protocol.QueryService_v1',
   file=DESCRIPTOR,
   index=1,
-  options=None,
+  serialized_options=None,
   serialized_start=927,
   serialized_end=1089,
   methods=[
@@ -314,7 +314,7 @@ _QUERYSERVICE_V1 = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=queries__pb2._QUERY,
     output_type=qry__responses__pb2._QUERYRESPONSE,
-    options=None,
+    serialized_options=None,
   ),
   _descriptor.MethodDescriptor(
     name='FetchCommits',
@@ -323,7 +323,7 @@ _QUERYSERVICE_V1 = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=queries__pb2._BLOCKSQUERY,
     output_type=qry__responses__pb2._BLOCKQUERYRESPONSE,
-    options=None,
+    serialized_options=None,
   ),
 ])
 _sym_db.RegisterServiceDescriptor(_QUERYSERVICE_V1)

--- a/iroha/iroha.py
+++ b/iroha/iroha.py
@@ -346,7 +346,7 @@ class IrohaGrpc(object):
         Request a status of a transaction
         :param transaction: the transaction, which status is about to be known
         :return: a tuple with the symbolic status description,
-        integral status code, and error message string (will be empty if no error occurred)
+        integral status code, and error code (will be 0 if no error occurred)
         :raise: grpc.RpcError with .code() available in case of any error
         """
         request = endpoint_pb2.TxStatusRequest()
@@ -359,7 +359,7 @@ class IrohaGrpc(object):
         Generator of transaction statuses from status stream
         :param transaction: the transaction, which status is about to be known
         :return: an iterable over a series of tuples with symbolic status description,
-        integral status code, and error message string (will be empty if no error occurred)
+        integral status code, and error code (will be 0 if no error occurred)
         :raise: grpc.RpcError with .code() available in case of any error
         """
         request = endpoint_pb2.TxStatusRequest()
@@ -375,9 +375,9 @@ class IrohaGrpc(object):
         Parse protocol.ToriiResponse into a tuple
         :param response: response to be parsed
         :return: a tuple with the symbolic status description,
-        integral status code, and error message string (will be empty if no error occurred)
+        integral status code, and error code (will be 0 if no error occurred)
         """
         status_name = endpoint_pb2.TxStatus.Name(response.tx_status)
         status_code = response.tx_status
-        error_message = response.error_message
-        return status_name, status_code, error_message
+        error_code = response.error_code
+        return status_name, status_code, error_code


### PR DESCRIPTION
### Description of the Change
- Remove exception handling in `IrohaGrpc` methods to make them consistent
- Refactor `send_txs` method with list to make it consistent with `batch` method in `Iroha`

### Benefits
Consistency

### Possible Drawbacks 
None
