### PR TITLE
Add timeout parameter to network calls. Prepare examples for CI

### DIFF
--- a/examples/batch-example.py
+++ b/examples/batch-example.py
@@ -7,7 +7,14 @@
 import binascii
 from iroha import IrohaCrypto as ic
 from iroha import Iroha, IrohaGrpc
+import os
 import sys
+
+IROHA_HOST_ADDR = os.getenv('IROHA_HOST_ADDR', '127.0.0.1')
+IROHA_PORT = os.getenv('IROHA_PORT', '50051')
+ADMIN_ACCOUNT_ID = os.getenv('ADMIN_ACCOUNT_ID', 'admin@test')
+ADMIN_PRIVATE_KEY = os.getenv(
+    'ADMIN_PRIVATE_KEY', 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70')
 
 print("""
 
@@ -18,10 +25,8 @@ PLEASE ENSURE THAT MST IS ENABLED IN IROHA CONFIG
 if sys.version_info[0] < 3:
     raise Exception('Python 3 or a more recent version is required.')
 
-iroha = Iroha('admin@test')
-net = IrohaGrpc()
-
-admin_private_key = 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70'
+iroha = Iroha(ADMIN_ACCOUNT_ID)
+net = IrohaGrpc('{}:{}'.format(IROHA_HOST_ADDR, IROHA_PORT))
 
 alice_private_keys = [
     'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506caba1',
@@ -97,7 +102,7 @@ def create_users():
                       asset_id='dogecoin#test', description='init doge', amount='20000')
     ]
     init_tx = iroha.transaction(init_cmds)
-    ic.sign_transaction(init_tx, admin_private_key)
+    ic.sign_transaction(init_tx, ADMIN_PRIVATE_KEY)
     send_transaction_and_print_status(init_tx)
 
 

--- a/examples/blocks-query.py
+++ b/examples/blocks-query.py
@@ -4,44 +4,45 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from iroha import Iroha, IrohaGrpc
+from iroha import IrohaCrypto
+import os
 import sys
+import time
+import uuid
 
 if sys.version_info[0] < 3:
     raise Exception('Python 3 or a more recent version is required.')
 
-from iroha import IrohaCrypto
-from iroha import Iroha, IrohaGrpc
+IROHA_HOST_ADDR = os.getenv('IROHA_HOST_ADDR', '127.0.0.1')
+IROHA_PORT = os.getenv('IROHA_PORT', '50051')
+ADMIN_ACCOUNT_ID = os.getenv('ADMIN_ACCOUNT_ID', 'admin@test')
+ADMIN_PRIVATE_KEY = os.getenv(
+    'ADMIN_PRIVATE_KEY', 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70')
 
-admin_private_key = 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70'
-iroha = Iroha('admin@test')
-net = IrohaGrpc()
-
-
-def trace(func):
-    """
-    A decorator for tracing methods' begin/end execution points
-    """
-
-    def tracer(*args, **kwargs):
-        name = func.__name__
-        print('\tEntering "{}"'.format(name))
-        result = func(*args, **kwargs)
-        print('\tLeaving "{}"'.format(name))
-        return result
-
-    return tracer
+iroha = Iroha(ADMIN_ACCOUNT_ID)
+net = IrohaGrpc('{}:{}'.format(IROHA_HOST_ADDR, IROHA_PORT))
 
 
-@trace
-def get_blocks():
-    """
-    Subscribe to blocks stream from the network
-    :return:
-    """
+def send_tx():
+    rand_name = uuid.uuid4().hex
+    rand_key = IrohaCrypto.private_key()
+    domain = ADMIN_ACCOUNT_ID.split('@')[1]
+    tx = iroha.transaction([
+        iroha.command('CreateAccount',
+                      account_name=rand_name,
+                      domain_id=domain,
+                      public_key=rand_key)
+    ])
+    IrohaCrypto.sign_transaction(tx, ADMIN_PRIVATE_KEY)
+    net.send_tx(tx)
+    print('tx is sent')
+
+
+if __name__ == '__main__':
     query = iroha.blocks_query()
-    IrohaCrypto.sign_query(query, admin_private_key)
-    for block in net.send_blocks_stream_query(query):
-        print('The next block arrived:', block)
-
-
-get_blocks()
+    IrohaCrypto.sign_query(query, ADMIN_PRIVATE_KEY)
+    blocks = net.send_blocks_stream_query(
+        query, timeout=120)  # timeout in seconds
+    send_tx()
+    print(next(blocks))

--- a/examples/infinite-blocks-stream.py
+++ b/examples/infinite-blocks-stream.py
@@ -18,8 +18,8 @@ ADMIN_ACCOUNT_ID = os.getenv('ADMIN_ACCOUNT_ID', 'admin@test')
 ADMIN_PRIVATE_KEY = os.getenv(
     'ADMIN_PRIVATE_KEY', 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70')
 
-iroha = Iroha('{}:{}'.format(IROHA_HOST_ADDR, IROHA_PORT))
-net = IrohaGrpc()
+iroha = Iroha(ADMIN_ACCOUNT_ID)
+net = IrohaGrpc('{}:{}'.format(IROHA_HOST_ADDR, IROHA_PORT))
 
 
 def trace(func):

--- a/examples/infinite-blocks-stream.py
+++ b/examples/infinite-blocks-stream.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from iroha import Iroha, IrohaGrpc
+from iroha import IrohaCrypto
+import sys
+import os
+
+if sys.version_info[0] < 3:
+    raise Exception('Python 3 or a more recent version is required.')
+
+IROHA_HOST_ADDR = os.getenv('IROHA_HOST_ADDR', '127.0.0.1')
+IROHA_PORT = os.getenv('IROHA_PORT', '50051')
+ADMIN_ACCOUNT_ID = os.getenv('ADMIN_ACCOUNT_ID', 'admin@test')
+ADMIN_PRIVATE_KEY = os.getenv(
+    'ADMIN_PRIVATE_KEY', 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70')
+
+iroha = Iroha('{}:{}'.format(IROHA_HOST_ADDR, IROHA_PORT))
+net = IrohaGrpc()
+
+
+def trace(func):
+    """
+    A decorator for tracing methods' begin/end execution points
+    """
+
+    def tracer(*args, **kwargs):
+        name = func.__name__
+        print('\tEntering "{}"'.format(name))
+        result = func(*args, **kwargs)
+        print('\tLeaving "{}"'.format(name))
+        return result
+
+    return tracer
+
+
+@trace
+def get_blocks():
+    """
+    Subscribe to blocks stream from the network
+    :return:
+    """
+    query = iroha.blocks_query()
+    IrohaCrypto.sign_query(query, ADMIN_PRIVATE_KEY)
+    for block in net.send_blocks_stream_query(query):
+        print('The next block arrived:', block)
+
+
+get_blocks()


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Make examples execution finite.
Examples now can read environment variables.
Add timeout parameter for network operations in IrohaGrpc.

### Benefits

A step towards CI automation.

### Usage Examples or Tests

Run irohad with default genesis.block and keys and run one of:
* tx-example.py
* batch-example.py
* blocks-query.py