### PR TITLE
Move IrohaCrypto._signature into a public method

### DIFF
--- a/iroha/iroha.py
+++ b/iroha/iroha.py
@@ -57,7 +57,7 @@ class IrohaCrypto(object):
         return hash
 
     @staticmethod
-    def _signature(message, private_key):
+    def signature(message, private_key):
         """
         Calculate signature for given message and private key
         :param message: proto that has payload message inside
@@ -85,7 +85,7 @@ class IrohaCrypto(object):
         assert len(private_keys), 'At least one private key has to be passed'
         signatures = []
         for private_key in private_keys:
-            signature = IrohaCrypto._signature(transaction, private_key)
+            signature = IrohaCrypto.signature(transaction, private_key)
             signatures.append(signature)
         transaction.signatures.extend(signatures)
         return transaction
@@ -98,7 +98,7 @@ class IrohaCrypto(object):
         :param private_key: hex string of private key to sign the query
         :return: the modified query
         """
-        signature = IrohaCrypto._signature(query, private_key)
+        signature = IrohaCrypto.signature(query, private_key)
         query.signature.CopyFrom(signature)
         return query
 


### PR DESCRIPTION
This would allow client interactive applications to easily check signature validity (e.g. if someone has changed an in-memory transaction, the signature would become invalid, and we would need to somehow notify the user).

The method was private, so that should not break the public API.