### PR TITLE
Fix dependencies for the package setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
         'protobuf>=3.8.0',
         'grpcio-tools>=1.12.1',
         'pysha3;python_version<"3.6"',
-
+        'pynacl>=1.4.0'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Add dependency to PyNaCL as it is required for support of different hashing algorithms (including most important ED25519 with default SHA2 hashing)