### PR TITLE
[refactor]: Rename `KURA_BLOCK_STORE_PATH` in `example/peer_config/config.json`

### DIFF
--- a/example/peer_config/config.json
+++ b/example/peer_config/config.json
@@ -25,7 +25,7 @@
   },
   "KURA": {
     "INIT_MODE": "strict",
-    "BLOCK_STORE_PATH": "./blocks"
+    "BLOCK_STORE_PATH": "./storage"
   },
   "BLOCK_SYNC": {
     "GOSSIP_PERIOD_MS": 10000,


### PR DESCRIPTION
Just for consistency with the change of `DEFAULT_BLOCK_STORE_PATH` from `./blocks` to `./storage` in https://github.com/hyperledger/iroha/pull/2701
