### PR TITLE
ci: Add dedicated workflow for pytests

### DIFF
--- a/.github/workflows/pr-pytests.yml
+++ b/.github/workflows/pr-pytests.yml
@@ -3,6 +3,8 @@ name: Iroha 2 pull request pytests
 on:
   repository_dispatch:
     types: [dispatch-event]
+  pull_request:
+    branches: [main]
 
 env:
   IROHA_REF: 2.0.0-pre-rc.22

--- a/.github/workflows/pr-pytests.yml
+++ b/.github/workflows/pr-pytests.yml
@@ -1,0 +1,43 @@
+name: Iroha 2 pull request pytests
+
+on:
+  repository_dispatch:
+    types: [dispatch-event]
+
+env:
+  IROHA_REF: 2.0.0-pre-rc.22
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.12 ]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install poetry
+      - name: Checkout iroha main repo code
+        uses: actions/checkout@v4
+        with:
+          repository: 'hyperledger/iroha'
+          ref: ${{ env.IROHA_REF}}
+      - name: Run docker-compose.yml containers
+        run: docker compose -f ./configs/swarm/docker-compose.yml up --wait || exit 1
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Maturin build
+        run: |
+          pip install maturin
+          maturin build
+          poetry add target/wheels/*
+      - name: Install project dependencies
+        run: poetry install
+      - name: Run tests
+        run: poetry run pytest tests
+      - name: Tear down docker containers
+        if: always()
+        run: docker stop $(docker ps -q) && docker rm $(docker ps -a -q)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,43 +38,6 @@ jobs:
           yapf --style pep8 -e 'iroha2/sys/**/*.py' -r -i iroha2 example
           git diff --quiet
 
-  pytest:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ 3.12 ]
-    steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install poetry
-      - name: Checkout Iroha code
-        uses: actions/checkout@v4
-        with:
-          repository: 'hyperledger/iroha'
-          ref: '2.0.0-pre-rc.22'
-      - name: Run docker-compose.yml containers
-        run: |
-          docker compose -f ./configs/swarm/docker-compose.yml up --wait || exit 1
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Maturin build
-        run: |
-          pip install maturin
-          maturin build
-          poetry add target/wheels/*
-      - name: Install project dependencies
-        run: poetry install
-      - name: Run tests
-        run: poetry run pytest tests
-      - name: Tear down Docker containers
-        if: always()
-        run: |
-          docker stop $(docker ps -q) && docker rm $(docker ps -a -q)
-
   integration-test:
     runs-on: iroha-ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
1. Move `pytest` job to the separated workflow to be able to trigger its run after iroha2-dev image publishing from the iroha-rust` repo.